### PR TITLE
chore(build): remove unnecessary build configuration

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,7 +3,3 @@ plugins {
 }
 
 rootProject.name = "hyginia"
-
-// Use stable configuration-cache:
-// https://docs.gradle.org/8.6/userguide/configuration_cache.html#config_cache:stable
-enableFeaturePreview("STABLE_CONFIGURATION_CACHE")


### PR DESCRIPTION
This is now Gradle default.
