### PR TITLE
chore(ci): replace gradle dep submission with CycloneDX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,32 @@ jobs:
       - uses: actions/checkout@v5
       - run: corepack enable
       - uses: ./.github/gradle-action
-      - uses: gradle/actions/dependency-submission@v4
+      # Generate CycloneDX (JSON). Disable config cache due to known Gradle 9 issue.
+      - name: Generate CycloneDX SBOM
+        run: ./gradlew :cyclonedxBom -x test --no-configuration-cache
+      # Convert CycloneDX → SPDX 2.2 using the CycloneDX CLI (supports spdx-json v2.2)
+      #    (Uses Docker image to avoid installing extra binaries)
+      - name: Convert CycloneDX → SPDX (JSON v2.2)
+        # language="shell script"
+        run: |
+         docker run --rm -v "$PWD:/work" cyclonedx/cyclonedx-cli:0.29.1 \
+           convert \
+             --input-file /work/build/reports/cyclonedx/bom.json \
+             --input-format json \
+             --output-format spdxjson \
+             --output-file /work/build/reports/cyclonedx/bom.spdx.json
+      # Keep artifacts for auditing
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cyclonedx-sbom
+          path: |
+            ./build/reports/cyclonedx/bom.json
+            ./build/reports/cyclonedx/bom.spdx.json
+      # Submit SPDX to GitHub Dependency Submission API
+      - name: Submit SPDX SBOM to GitHub
+        uses: advanced-security/spdx-dependency-submission-action@v0.1.1
+        with:
+          filePath: build/reports/cyclonedx/bom.spdx.json
 
   create-release:
     name: Creates a GitHub Release

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,8 @@ plugins {
     // To build the app ui frontend
     // https://siouan.github.io/frontend-gradle-plugin/
     id("org.siouan.frontend-jdk17") version "10.0.0"
+    // https://github.com/CycloneDX/cyclonedx-gradle-plugin
+    id("org.cyclonedx.bom") version "2.3.1"
 }
 
 val runningOnCI: Boolean = getenv().getOrDefault("CI", "false").toBoolean()
@@ -263,6 +265,22 @@ tasks {
         toDir = project.layout.buildDirectory.dir("test-results")
 
         mustRunAfter("test")
+    }
+
+    cyclonedxBom {
+        // CycloneDX schema (as string in 2.x)
+        schemaVersion = "1.6"
+
+        // Only include production configs
+        includeConfigs = listOf("runtimeClasspath", "compileClasspath")
+
+        // Exclude test / codegen / annotation processors etc.
+        skipConfigs = listOf(".*test.*", ".*Test.*", "kapt.*", "ksp.*", "annotationProcessor")
+
+        // Put output in a stable location and only JSON (workflow expects this)
+        destination = file("${layout.buildDirectory.asFile.get().absolutePath}/reports/cyclonedx")
+        outputName = "bom"
+        outputFormat = "json"
     }
 }
 


### PR DESCRIPTION
This will hopefully have a higher fidelity for used dependencies.
